### PR TITLE
Update jSnapLoader to Version 1.0.0-epsilon

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jolt-jni-linuxarm64 = { module = "com.github.stephengold:jolt-jni-Linux_ARM64", 
 jolt-jni-macosx64 = { module = "com.github.stephengold:jolt-jni-MacOSX64", version.ref = "jolt-jni" }
 jolt-jni-macosxarm64 = { module = "com.github.stephengold:jolt-jni-MacOSX_ARM64", version.ref = "jolt-jni" }
 jolt-jni-windows64 = { module = "com.github.stephengold:jolt-jni-Windows64", version.ref = "jolt-jni" }
-jsnaploader = "io.github.electrostat-lab:snaploader:1.0.0-epsilon"
+jsnaploader = "io.github.electrostat-lab:snaploader:1.0.0-epsilon-1"
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jolt-jni-linuxarm64 = { module = "com.github.stephengold:jolt-jni-Linux_ARM64", 
 jolt-jni-macosx64 = { module = "com.github.stephengold:jolt-jni-MacOSX64", version.ref = "jolt-jni" }
 jolt-jni-macosxarm64 = { module = "com.github.stephengold:jolt-jni-MacOSX_ARM64", version.ref = "jolt-jni" }
 jolt-jni-windows64 = { module = "com.github.stephengold:jolt-jni-Windows64", version.ref = "jolt-jni" }
-jsnaploader = "io.github.electrostat-lab:snaploader:1.0.0-delta"
+jsnaploader = "io.github.electrostat-lab:snaploader:1.0.0-epsilon"
 
 [bundles]
 

--- a/src/main/java/com/github/stephengold/snapjolt/HelloWorld.java
+++ b/src/main/java/com/github/stephengold/snapjolt/HelloWorld.java
@@ -72,7 +72,7 @@ public static void main(String[] argv)
         loader.setRetryWithCleanExtraction(true);
         try {
             loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new IllegalStateException("Failed to load the joltjni library!");
         }
 

--- a/src/main/java/com/github/stephengold/snapjolt/HelloWorld.java
+++ b/src/main/java/com/github/stephengold/snapjolt/HelloWorld.java
@@ -22,11 +22,11 @@ SOFTWARE.
 package com.github.stephengold.snapjolt;
 import com.github.stephengold.joltjni.*;
 import com.github.stephengold.joltjni.enumerate.*;
-import electrostatic.snaploader.LibraryInfo;
-import electrostatic.snaploader.LoadingCriterion;
-import electrostatic.snaploader.NativeBinaryLoader;
-import electrostatic.snaploader.platform.NativeDynamicLibrary;
-import electrostatic.snaploader.platform.util.PlatformPredicate;
+import electrostatic4j.snaploader.LibraryInfo;
+import electrostatic4j.snaploader.LoadingCriterion;
+import electrostatic4j.snaploader.NativeBinaryLoader;
+import electrostatic4j.snaploader.platform.NativeDynamicLibrary;
+import electrostatic4j.snaploader.platform.util.PlatformPredicate;
 import java.io.IOException;
 /**
  * A straightforward Java translation of the Jolt Physics "hello world" sample


### PR DESCRIPTION
This PR updates the jSnapLoader artifact version to `1.0.0-epsilon`, and applied the API breaking changes.