### PR TITLE
Updated to jSnapLoader 1.0.0-stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jolt-jni-linuxarm64 = { module = "com.github.stephengold:jolt-jni-Linux_ARM64", 
 jolt-jni-macosx64 = { module = "com.github.stephengold:jolt-jni-MacOSX64", version.ref = "jolt-jni" }
 jolt-jni-macosxarm64 = { module = "com.github.stephengold:jolt-jni-MacOSX_ARM64", version.ref = "jolt-jni" }
 jolt-jni-windows64 = { module = "com.github.stephengold:jolt-jni-Windows64", version.ref = "jolt-jni" }
-jsnaploader = "io.github.electrostat-lab:snaploader:1.0.0-epsilon-1"
+jsnaploader = "io.github.electrostat-lab:snaploader:1.0.0-stable"
 
 [bundles]
 

--- a/src/main/java/com/github/stephengold/snapjolt/HelloWorld.java
+++ b/src/main/java/com/github/stephengold/snapjolt/HelloWorld.java
@@ -20,14 +20,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 package com.github.stephengold.snapjolt;
+
 import com.github.stephengold.joltjni.*;
 import com.github.stephengold.joltjni.enumerate.*;
 import electrostatic4j.snaploader.LibraryInfo;
 import electrostatic4j.snaploader.LoadingCriterion;
 import electrostatic4j.snaploader.NativeBinaryLoader;
+import electrostatic4j.snaploader.filesystem.DirectoryPath;
 import electrostatic4j.snaploader.platform.NativeDynamicLibrary;
 import electrostatic4j.snaploader.platform.util.PlatformPredicate;
-import java.io.IOException;
+
 /**
  * A straightforward Java translation of the Jolt Physics "hello world" sample
  * application.
@@ -57,7 +59,8 @@ public class HelloWorld {
 // Program entry point
 public static void main(String[] argv)
 {
-        LibraryInfo info = new LibraryInfo(null, null, "joltjni", null);
+        LibraryInfo info = new LibraryInfo(new DirectoryPath("linux/x86-64/com/github/stephengold"),
+				"joltjni", DirectoryPath.USER_DIR);
         NativeBinaryLoader loader = new NativeBinaryLoader(info);
         NativeDynamicLibrary[] libraries = new NativeDynamicLibrary[] {
             new NativeDynamicLibrary("linux/aarch64/com/github/stephengold", PlatformPredicate.LINUX_ARM_64),


### PR DESCRIPTION
This PR updates jSnapLoader to _1.0.0-stable_. The stable version ships some optimization changes to the core API and to the `LibraryInfo` component which entail: 
- [x] Removing the nullary arguments to the _LibraryInfo_ constructor by wrapping String Paths in _DirectoryPath_ structures.
- [x] Better handling of file locator routines (classpath or external compression).
- [x] Stepwise validation strategy for stream providers using a _Validation_ API.
- [x] For the external compression routines file locators: dispatch `close()` on the _ZipFile_ resources itself (which closes all the associated enteries' streams) and not a single file entry of it.

I've tested the example locally multiple times; with normal execution flow, and with exceptional flows. Hopefully, there won't be any regressions or breaking changes so far on other systems.

Find more about these changes in [the stable version release notes](https://github.com/Electrostat-Lab/jSnapLoader/releases/tag/1.0.0-stable).

Notice: 
The first parameter in the `LibraryInfo` constructor method in this example is a placeholder path, and is never used unless the selected NativeDynamicLibrary object has a nullary library path (actually this placeholder will have contemplated features in the upcoming releases).